### PR TITLE
feat: Task 2 - 商品データモデルの定義

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -1,0 +1,12 @@
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class ProductModel(BaseModel):
+    """商品データモデル"""
+
+    id: int = Field(..., description="商品ID")
+    name: str = Field(..., min_length=1, description="商品名")
+    price: float = Field(..., gt=0, description="単価")
+    created_at: datetime = Field(default_factory=datetime.now, description="作成日時")

--- a/tests/api/test_models.py
+++ b/tests/api/test_models.py
@@ -1,0 +1,29 @@
+import pytest
+from pydantic import ValidationError
+
+from api.models import ProductModel
+
+
+def test_product_model_success() -> None:
+    """商品モデルが正常なデータで作成できることをテストする"""
+    data = {"id": 1, "name": "テスト商品", "price": 100.0}
+    product = ProductModel(**data)
+    assert product.id == data["id"]
+    assert product.name == data["name"]
+    assert product.price == data["price"]
+    assert product.created_at is not None
+
+
+def test_product_model_invalid_name() -> None:
+    """商品名が空文字の場合にバリデーションエラーが発生することをテストする"""
+    with pytest.raises(ValidationError):
+        ProductModel(id=1, name="", price=100.0)
+
+
+def test_product_model_invalid_price() -> None:
+    """価格が0以下の場合にバリデーションエラーが発生することをテストする"""
+    with pytest.raises(ValidationError):
+        ProductModel(id=1, name="テスト商品", price=0)
+
+    with pytest.raises(ValidationError):
+        ProductModel(id=1, name="テスト商品", price=-100)


### PR DESCRIPTION
## 概要
Task #2 の実装として、Pydanticを利用して商品データモデルを定義しました。

## 関連Issue
Fixes #2

## 実装内容
- `api/models.py` を作成し、`ProductModel` を定義
  - `id`: int
  - `name`: str (1文字以上)
  - `price`: float (0より大きい)
  - `created_at`: datetime
- モデルのバリデーションルールを検証するテスト (`tests/api/test_models.py`) を追加