### PR TITLE
feat: Task 5 - 商品取得エンドポイントの実装

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from starlette import status
 
 from .models import ProductCreate, ProductModel
@@ -23,3 +23,17 @@ async def health_check() -> dict[str, str]:
 async def create_item(item: ProductCreate) -> ProductModel:
     """新しい商品を作成する"""
     return storage.create_product(item)
+
+
+@app.get(
+    "/items/{item_id}",
+    response_model=ProductModel,
+    status_code=status.HTTP_200_OK,
+    summary="商品取得",
+)
+async def get_item(item_id: int) -> ProductModel:
+    """IDで指定された商品を取得する"""
+    product = storage.get_product(item_id)
+    if not product:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Product not found")
+    return product

--- a/api/storage.py
+++ b/api/storage.py
@@ -17,5 +17,5 @@ class InMemoryStorage:
         return product
 
     def get_product(self, product_id: int) -> ProductModel | None:
-        """商品IDを指定して商品を取得する (Task #5で実装)"""
-        raise NotImplementedError
+        """商品IDを指定して商品を取得する"""
+        return self._products.get(product_id)


### PR DESCRIPTION
## 概要
Task #5 の実装として、商品取得エンドポイント `GET /items/{id}` をTDDサイクルに従って実装しました。これにて、APIの全機能が完成です。

## 関連Issue
Fixes #5

## 実装内容
- `GET /items/{id}` エンドポイントを `api/main.py` に追加
- `InMemoryStorage` の `get_product` メソッドを実装
- 存在するIDで商品が取得できること（200 OK）をテスト
- 存在しないIDの場合に `404 Not Found` が返ることをテスト