### PR TITLE
feat(ui): Task 13 - session_state を利用した商品一覧表示

### DIFF
--- a/ui/main.py
+++ b/ui/main.py
@@ -14,6 +14,21 @@ def main() -> None:
     # --- 登録済み商品一覧 ---
     st.subheader("登録済み商品一覧")
 
+    # セッション状態に商品リストがなければ初期化
+    if "products" not in st.session_state:
+        st.session_state.products = []
+
+    # 商品一覧表示
+    if not st.session_state.products:
+        st.info("まだ商品が登録されていません。")
+    else:
+        for product in st.session_state.products:
+            with st.container():
+                st.write(f"ID: {product.get('id', 'N/A')}")
+                st.write(f"商品名: {product.get('name', 'N/A')}")
+                st.write(f"価格: {product.get('price', 'N/A')} 円")
+                st.write(f"登録日時: {product.get('created_at', 'N/A')}")
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## 概要
Task #13 の実装

## 関連Issue
Fixes #13

## 実装内容
- [x] `st.session_state` を使って、セッション内で商品を保持するリストを管理するロジックを追加
- [x] 商品リストが空の場合と、データが存在する場合で表示を切り替えるように実装

## 確認方法
```bash
cd ui
uv run streamlit run main.py
```
現時点ではAPI連携がないため、常に「まだ商品が登録されていません。」と表示されます。